### PR TITLE
Add documentation for stubbing multiple functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,4 +29,4 @@ Collate:
     'mock-object.R'
     'stub.R'
 VignetteBuilder: knitr
-RoxygenNote: 6.0.1
+RoxygenNote: 7.1.0

--- a/R/stub.R
+++ b/R/stub.R
@@ -41,6 +41,16 @@ NULL
 #' # now g() returns FALSE because f() has been stubbed out
 #' g()
 #' 
+#' # you can stub multiple functions by calling stub() multiple times 
+#' f <- function() TRUE
+#' g <- function() TRUE
+#' h <- function() any(f(), g())
+#' stub(h, 'f', FALSE)
+#' stub(h, 'g', FALSE)
+#' 
+#' # now h() returns FALSE because both f() and g() have been stubbed out
+#' h()
+#' 
 `stub` <- function (where, what, how, depth=1)
 {
     # `where` needs to be a function

--- a/man/mock.Rd
+++ b/man/mock.Rd
@@ -2,7 +2,6 @@
 % Please edit documentation in R/mock-object.R
 \name{mock}
 \alias{mock}
-\alias{mock}
 \alias{mock_args}
 \alias{mock_calls}
 \alias{length.mock}

--- a/man/mockery.Rd
+++ b/man/mockery.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{mockery}
 \alias{mockery}
-\alias{mockery-package}
 \title{R package to make mocking easier}
 \description{
 There are great tools for unit testing in R out there already but

--- a/man/stub.Rd
+++ b/man/stub.Rd
@@ -2,7 +2,6 @@
 % Please edit documentation in R/stub.R
 \name{stub}
 \alias{stub}
-\alias{stub}
 \title{Replace a function with a stub.}
 \usage{
 stub(where, what, how, depth = 1)
@@ -41,5 +40,15 @@ stub(g, 'f', FALSE)
 
 # now g() returns FALSE because f() has been stubbed out
 g()
+
+# you can stub multiple functions by calling stub() multiple times 
+f <- function() TRUE
+g <- function() TRUE
+h <- function() any(f(), g())
+stub(h, 'f', FALSE)
+stub(h, 'g', FALSE)
+
+# now h() returns FALSE because both f() and g() have been stubbed out
+h()
 
 }


### PR DESCRIPTION
This PR will fix #37 by adding a minimal example of multiple stubbing.

I added the example in the Roxygen documentation of `stub.R` and then I updated the documentation automatically by `devtools::document()`.
It produced some changes in some files as you can see, Roxygen version has been changed too as I have updated packages recently. Still, I think everything is ok.
I run `devtools::check()` successfully.