### PR TITLE
Fix issues with stubs of depth > 1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,9 @@ License: MIT + file LICENSE
 URL: https://github.com/r-lib/mockery
 BugReports: https://github.com/r-lib/mockery/issues
 Imports:
-    testthat
+    testthat,
+    withr,
+    restorepoint
 Suggests:
     knitr,
     R6,

--- a/R/stub.R
+++ b/R/stub.R
@@ -1,6 +1,3 @@
-library(restorepoint)
-library(withr)
-
 #' Replace a function with a stub.
 #'
 #' The result of calling \code{stub} is that, when \code{where}
@@ -63,7 +60,7 @@ NULL
 
     # set environment on where
     original = environment(where)
-    manipulable = clone.environment(original)
+    manipulable = restorepoint::clone.environment(original)
     environment(where) = manipulable
 
     test_env <- parent.frame()

--- a/R/stub.R
+++ b/R/stub.R
@@ -1,3 +1,5 @@
+library(restorepoint)
+library(withr)
 
 #' Replace a function with a stub.
 #'
@@ -60,9 +62,18 @@ NULL
     stopifnot(is.character(what), length(what) == 1)
 
     test_env <- parent.frame()
+    manipulable = clone.environment(environment(where))
+    original = clone.environment(environment(where))
+    environment(where) = manipulable
     tree <- build_function_tree(test_env, where, where_name, depth)
 
     mock_through_tree(tree, what, how)
+    withr::defer_parent(cleanup(original, where))
+
+}
+
+cleanup = function (restore, where) {
+    environment(where) = restore
 }
 
 mock_through_tree <- function(tree, what, how) {

--- a/R/stub.R
+++ b/R/stub.R
@@ -61,15 +61,16 @@ NULL
     # `what` needs to be a character value
     stopifnot(is.character(what), length(what) == 1)
 
-    test_env <- parent.frame()
-    manipulable = clone.environment(environment(where))
-    original = clone.environment(environment(where))
+    # set environment on where
+    original = environment(where)
+    manipulable = clone.environment(original)
     environment(where) = manipulable
+
+    test_env <- parent.frame()
     tree <- build_function_tree(test_env, where, where_name, depth)
 
     mock_through_tree(tree, what, how)
     withr::defer_parent(cleanup(original, where))
-
 }
 
 cleanup = function (restore, where) {

--- a/tests/testthat/test_stub.R
+++ b/tests/testthat/test_stub.R
@@ -359,3 +359,36 @@ test_that('stubs locked functions', {
     stub(f, 'h', stub_string, depth=2)
     expect_equal(f('not stub'), 'called stub!')
 })
+
+# tests for depth bug, from https://github.com/r-lib/mockery/issues/20#issue-280702346
+h = function()1
+g = function()h()
+f = function()g()
+
+test_that("stubbing works in a non-nested function", {
+	expect_equal(g(), 1)
+	stub(g, "h", 2)
+	expect_equal(g(), 2)
+})
+test_that("stubs do not carry over between test blocks", {
+	expect_equal(g(), 1)
+})
+
+test_that("stubbing works inside a nested function", {
+	expect_equal(f(), 1)
+	stub(f, "h", 2, depth=2)
+	expect_equal(f(), 2)
+})
+test_that("nested stubs do not carry over between test blocks", {
+	expect_equal(f(), 1)
+})
+
+g = function(y) y
+f = function(x) g(x) + 1
+r = function(x) g(x) + f(x)
+test_that('only calls from what are stubbed', {
+	stub(r, 'g', 100, depth=2)
+	expect_equal(r(1), 201)
+	expect_equal(g(1), 1)
+	expect_equal(f(1), 2)
+})


### PR DESCRIPTION
This pull request fixes two issues first raised in https://github.com/r-lib/mockery/issues/20.

1. When depth > 1, the function to stub is stubbed out from functions other than `where`.

2. When depth > 1, the stub persists past the end of the test function.

One or both of these issues were also raised in https://github.com/r-lib/mockery/issues/66 and https://github.com/r-lib/mockery/issues/57.
